### PR TITLE
feat: :sparkles: Make getentropy a weak function

### DIFF
--- a/src/system/stubs.cpp
+++ b/src/system/stubs.cpp
@@ -137,8 +137,9 @@ unsigned sleep(unsigned period) {
 	return 1;
 }
 
-// get entropy. Not implemented
-int getentropy(void* _buffer, size_t _length) {
+// get entropy. Zestcode does not implement this function, but other
+// libraries can, which is why this function is marked as weak
+[[gnu::weak]] int getentropy(void* _buffer, size_t _length) {
 	errno = ENOSYS;
 	return -1;
 }


### PR DESCRIPTION
#### Overview
Makes `getentropy()` a weak function.

#### Motivation
This allows users to implement it themselves using whatever source of randomness they desire.

#### References
Closes #17 

#### Test Plan:
- [ ] Test that getentropy can be overridden
