### PR TITLE
:art: change enum naming style

### DIFF
--- a/docs/STYLEGUIDE.md
+++ b/docs/STYLEGUIDE.md
@@ -43,12 +43,13 @@ For more details, see [.clang-format](../.clang-format).
 
 - **files, folders** - snake_case
 - **classes, structs, enums, unions, concepts, etc** - PascalCase
-- - **enum members** - PascalCase
+  - **enum members** - PascalCase
+  - edge case: names including acronyms shouldn't have consecutive capital letters. Eg: `HTTPRequest` should be `HttpRequst`
 - **functions** - snake_case
 - **variables** - snake_case
 - **member variables** - m_snake_case (The `m_` is intentional)
 - **macros** - SCREAMING_SNAKE_CASE
-- **compile-time constants** - SCREAMING_SNAKE_CASE
+- **constexpr constants** - SCREAMING_SNAKE_CASE
 
 ## Documentation
 

--- a/docs/STYLEGUIDE.md
+++ b/docs/STYLEGUIDE.md
@@ -44,7 +44,7 @@ For more details, see [.clang-format](../.clang-format).
 - **files, folders** - snake_case
 - **classes, structs, enums, unions, concepts, etc** - PascalCase
   - **enum members** - PascalCase
-  - edge case: names including acronyms shouldn't have consecutive capital letters. Eg: `HTTPRequest` should be `HttpRequst`
+  - **edge case** - names like `HTTPRequest` should be `HttpRequst`
 - **functions** - snake_case
 - **variables** - snake_case
 - **member variables** - m_snake_case (The `m_` is intentional)

--- a/docs/STYLEGUIDE.md
+++ b/docs/STYLEGUIDE.md
@@ -43,12 +43,12 @@ For more details, see [.clang-format](../.clang-format).
 
 - **files, folders** - snake_case
 - **classes, structs, enums, unions, concepts, etc** - PascalCase
+- - **enum members** - PascalCase
 - **functions** - snake_case
 - **variables** - snake_case
 - **member variables** - m_snake_case (The `m_` is intentional)
 - **macros** - SCREAMING_SNAKE_CASE
 - **compile-time constants** - SCREAMING_SNAKE_CASE
-- **enum members** - snake_case
 
 ## Documentation
 


### PR DESCRIPTION
#### Overview
Changes enum naming style from `MyEnum::my_variant` to `MyEnum::MyVariant`

#### Motivation
It's a better way of naming. It's less ambiguous, as `MyEnum::my_variant` is the same as `MyClass::my_static_variable`
