### PR TITLE
create basic Result class with conversion operators

### DIFF
--- a/include/common/result.hpp
+++ b/include/common/result.hpp
@@ -1,328 +1,155 @@
 #pragma once
 
-#include <chrono>
 #include <concepts>
-#include <limits>
 #include <optional>
-#include <stacktrace>
-#include <variant>
+#include <type_traits>
+#include <utility>
 
 namespace zest {
 
 /**
- * @brief Base class for custom error types used in the Result class.
+ * @brief Helper class for error handling.
  *
- */
-class ResultError {
-  public:
-    /**
-     * @brief struct containing data that can only be known at runtime.
-     *
-     */
-    struct RuntimeData {
-        std::stacktrace stacktrace;
-        std::chrono::time_point<std::chrono::system_clock> time;
-    };
-
-    /**
-     * @brief Construct a new ResultError object.
-     *
-     * @details Captures the current stacktrace and system time if called at runtime.
-     */
-    constexpr ResultError() {
-        if !consteval {
-            runtime_data = {
-                .stacktrace = std::stacktrace::current(),
-                .time = std::chrono::system_clock::now()
-            };
-        }
-    }
-
-    std::optional<RuntimeData> runtime_data;
-};
-
-/**
- * @brief Unknown Error
+ * @tparam T "normal" type
+ * @tparam E "error" type
  *
+ * Constraints:
+ * - E must be a scoped enum
+ * - E must not be implicitly convertible to T
+ * - E must not be equality comparable with T
  */
-class UnknownError : public ResultError {
-  public:
-    template<typename T>
-        requires std::convertible_to<T, std::string>
-    UnknownError(T&& message)
-        : message(std::forward<T>(message)) {}
-
-    std::string message;
-};
-
-/**
- * @brief Trait to define a "sentinel" value for types indicating an error state.
- * @tparam T Type to provide a sentinel value for.
- * @note Specialize this template for custom types if needed.
- */
-template<typename T>
-class SentinelValue;
-
-/**
- * @brief Concept to check if a type has a defined sentinel value.
- * @tparam T Type to check.
- */
-template<typename T>
-concept Sentinel = requires(const T& val) { SentinelValue<T>::value; };
-
-/**
- * @brief Helper variable to simplify access to a type's sentinel value.
- * @tparam T Type with a defined sentinel (must satisfy Sentinel concept).
- */
-template<Sentinel T>
-constexpr T sentinel_v = SentinelValue<T>::value;
-
-/**
- * @brief Partial specialization of SentinelValue for integral and floating-point types.
- * @tparam T Integral or floating-point type.
- * @details Uses infinity for floating-point types if available; otherwise uses max value.
- */
-template<typename T>
-    requires(std::integral<T> || std::floating_point<T>)
-class SentinelValue<T> {
-  public:
-    static constexpr T get() {
-        if constexpr (std::numeric_limits<T>::has_infinity) {
-            return std::numeric_limits<T>::infinity();
-        } else {
-            return std::numeric_limits<T>::max();
-        }
-    }
-
-    static constexpr T value = get(); ///< Precomputed sentinel value for type T.
-};
-
-/**
- * @brief Result class for expected value or error handling (similar to std::expected).
- * @tparam T Type of the expected value.
- * @tparam Errs List of possible error types (must inherit from ResultError).
- * @note Errors are stored in a variant, and the value is always initialized.
- */
-template<typename T, typename... Errs>
-    requires(sizeof...(Errs) > 0) && (std::derived_from<Errs, ResultError> && ...)
+template<typename T, typename E>
+    requires std::is_scoped_enum_v<E> && (!std::convertible_to<E, T>)
+             && (!std::equality_comparable_with<T, E>)
 class Result {
   public:
+    std::optional<E> error;
+    T value;
+
     /**
-     * @brief Construct a Result with a normal value (no error).
-     * @tparam U Type convertible to T.
-     * @param value Value to initialize the result with.
+     * @brief default constructor
+     *
+     * Constraints:
+     * - T must have a default constructor
+     */
+    constexpr Result()
+        requires std::default_initializable<T>
+    = default;
+
+    /**
+     * @brief Construct with a "normal" value, and no error value
+     *
+     * @tparam U argument type
+     *
+     * @param value argument to initialize the "normal" value with
+     *
+     * Constraints:
+     * - T must be constructible with perfectly forwarded value argument
      */
     template<typename U>
-        requires std::constructible_from<T, U>
+        requires std::constructible_from<T, U&&>
     constexpr Result(U&& value)
-        : error(std::monostate()),
+        : value(std::forward<U>(value)) {}
+
+    /**
+     * @brief Construct with an "error" value, and the default "normal" value
+     *
+     * @param error argument to initialize the "error" value with
+     *
+     * Constraints:
+     * - T must be default initializable
+     */
+    constexpr Result(E error)
+        requires std::default_initializable<T>
+        : error(error) {}
+
+    /**
+     * @brief Construct with an "error" value and "normal" value
+     *
+     * @tparam U value argument type
+     *
+     * @param error argument to initialize the "error" value with
+     * @param value argument to initialize the "normal" value with
+     *
+     * Constraints:
+     * - T must be constructible with perfectly forwarded value argument
+     */
+    template<typename U>
+        requires std::constructible_from<T, U&&>
+    constexpr Result(E error, U&& value)
+        : error(error),
           value(std::forward<U>(value)) {}
 
     /**
-     * @brief Construct a Result with a value and an error.
-     * @tparam U Type convertible to T.
-     * @tparam E Error type (must be in Errs).
-     * @param value Value to store.
-     * @param error Error to store.
+     * @brief conversion operator for an l-value reference to the "normal" value type
+     *
+     * @return T&
      */
-    template<typename U, typename E>
-        requires std::constructible_from<T, U>
-                     && (std::same_as<std::remove_cvref_t<E>, Errs> || ...)
-    constexpr Result(U&& value, E&& error)
-        : value(std::forward<U>(value)),
-          error(std::forward<E>(error)) {}
-
-    /**
-     * @brief Construct a Result with an error, initializing the value to its sentinel.
-     * @tparam E Error type (must be in Errs).
-     * @param error Error to store.
-     * @note Requires T to have a defined sentinel value (via SentinelValue<T>).
-     */
-    template<typename E>
-        requires Sentinel<T> && (std::same_as<std::remove_cvref_t<E>, Errs> || ...)
-    constexpr Result(E&& error)
-        : error(std::forward<E>(error)),
-          value(sentinel_v<T>) {}
-
-    /**
-     * @brief Get an error of type E if present (const-qualified overload).
-     * @tparam E Error type to retrieve.
-     * @return std::optional<E> Contains the error if present; otherwise nullopt.
-     */
-    template<typename E>
-        requires(std::same_as<E, Errs> || ...)
-    constexpr std::optional<E> get() const& {
-        if (std::holds_alternative<E>(error)) {
-            return std::get<E>(error);
-        } else {
-            return std::nullopt;
-        }
-    }
-
-    /**
-     * @brief Get an error of type E if present (rvalue overload).
-     * @tparam E Error type to retrieve.
-     * @return std::optional<E> Contains the error if present; otherwise nullopt.
-     */
-    template<typename E>
-        requires(std::same_as<E, Errs> || ...)
-    constexpr std::optional<E> get() && {
-        if (std::holds_alternative<E>(error)) {
-            return std::move(std::get<E>(error));
-        } else {
-            return std::nullopt;
-        }
-    }
-
-    /**
-     * @brief Get an error of type E if present (const rvalue overload).
-     * @tparam E Error type to retrieve.
-     * @return std::optional<E> Contains the error if present; otherwise nullopt.
-     */
-    template<typename E>
-        requires(std::same_as<E, Errs> || ...)
-    constexpr const std::optional<E> get() const&& {
-        if (std::holds_alternative<E>(error)) {
-            return std::move(std::get<E>(error));
-        } else {
-            return std::nullopt;
-        }
-    }
-
-    /**
-     * @brief Get the stored value (const-qualified overload).
-     * @return T Copy of the stored value.
-     */
-    template<typename U = T>
-        requires std::same_as<U, T>
-    constexpr T get() const& {
-        return value;
-    }
-
-    /**
-     * @brief Get the stored value (rvalue overload).
-     * @return T Moved value.
-     */
-    template<typename U = T>
-        requires std::same_as<U, T>
-    constexpr T get() && {
-        return std::move(value);
-    }
-
     constexpr operator T&() & {
         return value;
     }
 
+    /**
+     * @brief conversion operator for a const l-value reference to the "normal" value type
+     *
+     * @return const T&
+     */
     constexpr operator const T&() const& {
         return value;
-    };
-
-    constexpr operator T&&() && {
-        return std::move(value);
-    }
-
-    constexpr operator const T&&() const&& {
-        return std::move(value);
     }
 
     /**
-     * @brief error value
-     * @details instead of wrapping the variant in std::optional, it's more efficient to use
-     * std::monostate. since we have to use std::variant in any case.
+     * @brief conversion operator for an r-value reference to the "normal" value type
+     *
+     * @return T&&
      */
-    std::variant<std::monostate, Errs...> error;
-    T value;
+    constexpr operator T&&() && {
+        return std::move(value);
+    }
 };
 
+} // namespace zest
+
 /**
- * @brief compare Result instances with comparable normal values
+ * @brief Compare the equality of 2 Result instances
  *
- * @tparam LhsT the normal value type of the left-hand side argument
- * @tparam RhsT the normal value type of the right-hand side argument
- * @tparam LhsErrs the error value types of the left-hand side argument
- * @tparam RhsErrs the error value types of the right-hand side argument
- * @param lhs the left-hand side of the expression
- * @param rhs the right-hand side of the expression
- * @return true if the values are equal
- * @return false if the values are not equal
+ * @note this function is defined in order to prevent ambiguous overload resolution.
+ *
+ * @tparam LhsT "normal" type of left-hand side object
+ * @tparam RhsT "normal" type of right-hand side object
+ * @tparam LhsE "error" type of left-hand side object
+ * @tparam RhsE "error" type of right-hand side object
+ *
+ * @param lhs left-hand side object
+ * @param rhs right-hand side object
+ *
+ * @return true "normal" values are equal.
+ * @return false "normal" values are not equal.
  */
-template<typename LhsT, typename RhsT, typename... LhsErrs, typename... RhsErrs>
+template<typename LhsT, typename RhsT, typename LhsE, typename RhsE>
     requires std::equality_comparable_with<LhsT, RhsT>
 constexpr bool
-operator==(const Result<LhsT, LhsErrs...>& lhs, const Result<RhsT, RhsErrs...>& rhs) {
+operator==(const zest::Result<LhsT, LhsE>& lhs, const zest::Result<RhsT, RhsE>& rhs) {
     return lhs.value == rhs.value;
 }
 
 /**
- * @brief Result specialization for void value type (no stored value).
- * @tparam Errs List of possible error types (must inherit from ResultError).
+ * @brief Compare a Result instance with an instance of its error type. If the Result instance
+ * contains the same error value, evaluates to true. If the Result instance does not contain the
+ * same error value, evaluates to false.
+ *
+ * @tparam T "normal" type of the Result instance
+ * @tparam E "error" type of the Result instance
+ *
+ * @param result Result instance to compare
+ * @param error error instance to compare
+ *
+ * @return true instance contains the same error value.
+ * @return false instance does not contain the same error value.
  */
-template<typename... Errs>
-    requires(sizeof...(Errs) > 0) && (std::derived_from<Errs, ResultError> && ...)
-class Result<void, Errs...> {
-  public:
-    /**
-     * @brief Construct a Result with an error.
-     * @tparam E Error type (must be in Errs).
-     * @param error Error to store.
-     */
-    template<typename E>
-        requires(std::same_as<std::remove_cvref_t<E>, Errs> || ...)
-    constexpr Result(E&& error)
-        : error(std::forward<E>(error)) {}
-
-    /**
-     * @brief Construct a Result with no error (success state).
-     */
-    constexpr Result()
-        : error(std::monostate()) {}
-
-    /**
-     * @brief Get an error of type E if present (const-qualified overload).
-     * @tparam E Error type to retrieve.
-     * @return std::optional<E> Contains the error if present; otherwise nullopt.
-     */
-    template<typename E>
-        requires(std::same_as<E, Errs> || ...)
-    constexpr std::optional<E> get() const& {
-        if (std::holds_alternative<E>(error)) {
-            return std::get<E>(error);
-        } else {
-            return std::nullopt;
-        }
-    }
-
-    /**
-     * @brief Get an error of type E if present (rvalue overload).
-     * @tparam E Error type to retrieve.
-     * @return std::optional<E> Contains the error if present; otherwise nullopt.
-     */
-    template<typename E>
-        requires(std::same_as<E, Errs> || ...)
-    constexpr std::optional<E> get() && {
-        if (std::holds_alternative<E>(error)) {
-            return std::move(std::get<E>(error));
-        } else {
-            return std::nullopt;
-        }
-    }
-
-    /**
-     * @brief Get an error of type E if present (const rvalue overload).
-     * @tparam E Error type to retrieve.
-     * @return std::optional<E> Contains the error if present; otherwise nullopt.
-     */
-    template<typename E>
-        requires(std::same_as<E, Errs> || ...)
-    constexpr const std::optional<E> get() const&& {
-        if (std::holds_alternative<E>(error)) {
-            return std::move(std::get<E>(error));
-        } else {
-            return std::nullopt;
-        }
-    }
-
-    std::variant<std::monostate, Errs...> error; ///< Variant holding an error or monostate.
-};
-
-} // namespace zest
+template<typename T, typename E>
+constexpr bool operator==(const zest::Result<T, E>& result, E error) {
+    if (!result.error.has_value())
+        return false;
+    return result.error.value() == error;
+}


### PR DESCRIPTION
#### Overview
Rewrite the Result class to a simplified errno replacement

#### Motivation
The existing approach is complex and hard to maintain

#### Implementation Details (optional)
The Result class contains an error value wrapped using std::optional, and a normal value. Instances can convert implicitly to the normal value type. The error type must be a scoped enum.

#### Test Plan:

